### PR TITLE
migrations: upgrade to .net 8.0 with azure and the vs code extensions for c# and .net

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": ".NET",
+  "name": ".NET on Azure",
   // See complete list https://hub.docker.com/_/microsoft-dotnet-sdk/
   // Or https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
   "image": "mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim",
@@ -23,22 +23,34 @@
       "dockerDashComposeVersion": "v2"
     },
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/azure/azure-dev/azd:0": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {
       "extensions": "azure-devops, containerapp, staticwebapp"
+    },
+    "ghcr.io/azure/azure-dev/azd:latest": {},
+    "ghcr.io/dapr/cli/dapr-cli:0": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "minikube": "none"
+    },
+
+    // Read more https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "latest",
+      "tflint": "latest",
+      "terragrunt": "latest"
     }
   },
   "containerEnv": {
-    // Set ASP.NET environment settings.
-    "ASPNETCORE_URLS": "http://+:8080;https://+:8081",
-    "ASPNETCORE_ENVIRONMENT": "Development",
     // Set dotnet CLI environment settings.
+    "DOTNET_RUNNING_IN_CONTAINER": "1",
+    "DOTNET_USE_POLLING_FILE_WATCHER": "1",
     "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
     "DOTNET_GENERATE_ASPNET_CERTIFICATE": "1",
-    "DOTNET_NOLOGO": "1"
+    "DOTNET_NOLOGO": "1",
+    // Set ASP.NET environment settings.
+    "ASPNETCORE_URLS": "http://+:8080;https://+:8081",
+    "ASPNETCORE_ENVIRONMENT": "Development"
   },
   "remoteEnv": {
-    "DOTNET_MULTILEVEL_LOOKUP": "0",
     "TARGET": "net8.0"
   },
   // Configure tool-specific properties.
@@ -47,40 +59,35 @@
     "vscode": {
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
+        // Read more https://github.com/microsoft/vscode-dotnettools/issues/562
+        // "ms-dotnettools.csdevkit",
+        "VisualStudioExptTeam.vscodeintellicode-insiders",
+        "ms-dotnettools.vscode-dotnet-runtime",
         "ms-dotnettools.csharp",
-        "ms-dotnettools.csdevkit",
-        "visualstudioexptteam.vscodeintellicode-insiders",
-        "VisualStudioExptTeam.vscodeintellicode-completions",
 
-        "editorconfig.editorconfig",
-
-        "ms-vscode.azurecli",
-        "ms-azuretools.azure-dev",
-        "ms-azuretools.vscode-docker",
-
-        "redhat.vscode-yaml",
-
+        "ms-vscode.vscode-node-azure-pack",
         "ms-mssql.mssql",
-
         "humao.rest-client",
 
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "albert.tabout",
         "streetsidesoftware.code-spell-checker",
         "redhat.fabric8-analytics"
       ],
       // Set *default* container specific settings.json values on container create.
       "settings": {
-        "omnisharp.enableAsyncCompletion": true,
-        "omnisharp.enableImportCompletion": true,
-        "omnisharp.enableRoslynAnalyzers": true,
+        "bicep.enableSurveys": false,
+        "redhat.telemetry.enabled": false,
+        "rest-client.previewOption": "exchange",
+        // Fix for ARM-based devices.
+        // Read more https://github.com/OmniSharp/omnisharp-vscode/issues/4348#issuecomment-1003867594
+        "omnisharp.useModernNet": true,
         "omnisharp.organizeImportsOnFormat": true,
         "omnisharp.useEditorFormattingSettings": true,
         "omnisharp.enableEditorConfigSupport": true,
-        // Fix for ARM-based devices.
-        // Read more https://github.com/OmniSharp/omnisharp-vscode/issues/4348#issuecomment-1003867594
-        "omnisharp.path": "latest",
-        "omnisharp.sdkIncludePrereleases": true,
-        "omnisharp.useModernNet": true,
-        "razor.disabled": true,
+
+        "razor.disabled": true
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,12 @@
     "ghcr.io/devcontainers/features/azure-cli:1": {
       "extensions": "azure-devops, containerapp, staticwebapp"
     },
-    "ghcr.io/devcontainers/features/terraform:1": {}
+    // HACK: https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "latest",
+      "tflint": "latest",
+      "terragrunt": "latest"
+    },
   },
   "containerEnv": {
     // Set ASP.NET environment settings.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,25 +18,15 @@
       "configureZshAsDefaultShell": true
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/dapr/cli/dapr-cli:0": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false,
       "dockerDashComposeVersion": "v2"
-    },
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "minikube": "none"
     },
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/azure/azure-dev/azd:0": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {
       "extensions": "azure-devops, containerapp, staticwebapp"
-    },
-    // HACK: https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
-    "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "latest",
-      "tflint": "latest",
-      "terragrunt": "latest"
-    },
+    }
   },
   "containerEnv": {
     // Set ASP.NET environment settings.
@@ -59,7 +49,6 @@
       "extensions": [
         "ms-dotnettools.csharp",
         "ms-dotnettools.csdevkit",
-
         "visualstudioexptteam.vscodeintellicode-insiders",
         "VisualStudioExptTeam.vscodeintellicode-completions",
 
@@ -67,33 +56,19 @@
 
         "ms-vscode.azurecli",
         "ms-azuretools.azure-dev",
-
         "ms-azuretools.vscode-docker",
-        "ms-kubernetes-tools.vscode-kubernetes-tools",
-        "ms-azuretools.vscode-azurecontainerapps",
-        "ms-azuretools.vscode-dapr",
 
         "redhat.vscode-yaml",
-        "ms-azure-devops.azure-pipelines",
-        // "GitHub.vscode-github-actions",
 
-        "bierner.github-markdown-preview",
-        // This ext is bundled with mssql and will be installed automatically.
-        // Database projects can be handled via Azure Data Studio.
-        // "ms-mssql.sql-database-projects-vscode",
         "ms-mssql.mssql",
 
         "humao.rest-client",
 
-        "ms-vscode.wordcount",
         "streetsidesoftware.code-spell-checker",
         "redhat.fabric8-analytics"
       ],
       // Set *default* container specific settings.json values on container create.
       "settings": {
-        "files.associations": {
-          "**/ci/*.yml": "azure-pipelines"
-        },
         "omnisharp.enableAsyncCompletion": true,
         "omnisharp.enableImportCompletion": true,
         "omnisharp.enableRoslynAnalyzers": true,

--- a/README.md
+++ b/README.md
@@ -1,95 +1,71 @@
-# Tryout Azure & .NET Stuff
+# Try .NET on Azure
 
 [<img align="right" alt=".NET C-sharp" width="128rem" src="https://raw.githubusercontent.com/github/explore/93d8a67084f94b2a444e510199a6e7622e5b09a3/topics/dotnet/dotnet.png" />][dotnet-quick-start]
 
-This template repo serves as a flavor of ready-to-go .NET and Azure development container.
+Start a dev container from a template and get to developing with C# leveraging .NET on Azure.
 
 > Originally, this dev container was created to tryout [.NET preview versions][dotnet-versions] without having to install them locally.
 
 [dotnet-quick-start]: https://learn.microsoft.com/en-us/dotnet/standard/get-started
-[dotnet-versions]: https://versionsof.net/core/
-
-### What's included:
-
-Technically, this includes nothing but:
-
-- .NET 8.0 SDK and Azure CLI to build, run, and publish to cloud
-- Docker and Kubernetes with Helm Charts for containers and for orchestrations
-- Bicep and Terraform to manage infrastructure code (or IaaC)
-- Node and Yarn for JavaScript-based apps and services
-
-## Requirements
-
-See [dev containers][devcontainers-use] to get started at the most basic level, and:
-
-- A GitHub account, and
-- [VS Code][vscode-download] with [recommended](./vscode/extensions.json) extensions
-
-[devcontainers-use]: https://containers.dev/supporting
-[vscode-download]: https://code.visualstudio.com/
+[dotnet-versions]: https://versionsof.net
 
 
 
-## Quick start
+## Quick Start
 
 [![Open in Dev Container](https://img.shields.io/static/v1?style=for-the-badge&label=Dev+Container&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/alertbox/devcontainers-azure-dotnet)
 
-If you are completely new to .NET and C#, the [@dotnet YouTube Channel][yt-dotnet-playlists] is a good source of information.
+
+
+You can also run this repo locally by following these repetitive steps:
+
+1. You want to ensure the repo is cloned to your local machine, and 
+2. Open it in VS Code.
+
+### Run Options
+
+[See .NET Docker Images][dotnet-docker-images] for other variations that suites your hardware.
+
+[dotnet-docker-images]: https://hub.docker.com/_/microsoft-dotnet-sdk/
+
+
+
+## Learn More
+
+If you are completely new to C# and .NET, the [@dotnet YouTube Channel][yt-dotnet-playlists] is a good source to learn the basics.
 
 [yt-dotnet-playlists]: https://www.youtube.com/@dotnet/playlists
 
 
 
-First, you want to ensure the repo is `Reopened in Container`. Then you'll be able to work on .NET and Azure stuff like you would locally.
-
-With VS Code:
-
-1. In a Terminal, run `dotnet --info` to see required versions are installed.
-2. Run `az --version` to verify Azure CLI is installed.
-
-
-
-## Build and run from source
-
-VS Code is integrated with Omnisharp Tools to run the web api on the dev container.
-
-With VS Code:
-
-1. Press `F5` to launch the project. Terminal shows the output from the Debug Console.
-2. When the web api executes, visit [localhost:8081/swagger](https://localhost:8081/swagger) on your favorite browser.
-3. Press `Ctrl`+`C` to stop and disconnect the debugger.
-
-
-
-## Known issues
-
-- https://github.com/devcontainers/features/issues/440
-- https://github.com/azure/azure-functions-core-tools/issues/3112
-- https://github.com/omnisharp/omnisharp-vscode/issues/4348
-
-
-
-## Useful resources
-
 - [Dev Containers specification][devcontainers-json-spec] is a good source to learn more about `.devcontainer.json` configuration options and its usage.
 - [See .NET CLI page][ms-docs-dotnet-cli] to learn the full-blown `dotnet` options.
 - [See Azure CLI page][ms-docs-azure-cli] to learn what can be done with `az` and `az pipelines`.
 - [See Azure DevOps CLI page][ms-docs-azure-devops-cli] to learn what can be done with `az devops` .
-- [See .NET Docker Images][dotnet-docker-images] for alternative versions as you wish.
+
+
 
 [devcontainers-json-spec]: https://containers.dev/implementors/json_reference/
 [ms-docs-dotnet-cli]: https://docs.microsoft.com/en-us/dotnet/core/tools/
 [ms-docs-azure-cli]: https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest
 [ms-docs-azure-devops-cli]: https://learn.microsoft.com/en-us/azure/devops/cli/?view=azure-devops
-[dotnet-docker-images]: https://hub.docker.com/_/microsoft-dotnet-sdk/
 
 
 
-## Feedback
+## Troubleshooting
 
 If you have any technical problems with dev containers, you are better off asking [Dev Containers Support][devcontainers-support] directly, since you'll end up getting a much faster response back that way.
 
 [devcontainers-support]: https://github.com/devcontainers/community/discussions/3
+
+
+
+### Known Issues
+
+- https://github.com/omnisharp/omnisharp-vscode/issues/4348
+- https://github.com/devcontainers/features/issues/440
+- https://github.com/microsoft/vscode-dotnettools/issues/562
+- https://github.com/azure/azure-functions-core-tools/issues/3112
 
 
 


### PR DESCRIPTION
this changeset is to upgrade the dev container to use the latest .net 8.0 version along with azure.

- use the .net 8.0 bookworm slim docker image
- remove redundant vs code extensions because the correct extensions are added by the dev container features
- remove outdated and unwanted vs code customization settings
- fix terraform not getting installed due to issue https://github.com/hashicorp/vscode-terraform/issues/1524
- stop using c# dev kit extension due to issue https://github.com/microsoft/vscode-dotnettools/issues/562
- turn off telemetry for dapr and dotnet
- docs: reword, simplify, and improve README.md content